### PR TITLE
Make math match uspsa.org and take MRO into account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
-dist/
+dist/bundle.js
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
-dist/bundle.js
+dist/bundle.js*
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "args": [
+                "-u",
+                "tdd",
+                "--timeout",
+                "999999",
+                "--colors",
+                "--config-file",
+                "${workspaceFolder}/.mocharc.json",
+                "${workspaceFolder}/test"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "name": "uspsaprogress",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
+        "@types/lodash": "^4.17.18",
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.0.3",
         "mocha": "^11.6.0",
@@ -580,6 +584,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.18.tgz",
+      "integrity": "sha512-KJ65INaxqxmU6EoCiJmRPZC9H9RVWCRd349tXM2M3O5NA7cY6YL7c0bHAHQ93NOfTObEQ004kd2QVHs/r0+m4g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1864,6 +1875,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/uspsaprogress/progress#readme",
   "devDependencies": {
+    "@types/lodash": "^4.17.18",
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.3",
     "mocha": "^11.6.0",
@@ -29,5 +30,8 @@
     "typescript": "^5.8.3",
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }

--- a/src/classifications.ts
+++ b/src/classifications.ts
@@ -1,8 +1,28 @@
 export interface ClassifierScore {
     date: Date,
     classifierNumber: string,
-    club: string,
-    flag: string,
     percent: number,
-    hitFactor: number
+    club?: string,
+    flag?: string,
+    hitFactor?: number
+}
+
+export class RollingWindow {
+    constructor(public readonly scores: ClassifierScore[]) {
+        this.canScore = scores.length >= 6;
+    }
+
+    public readonly canScore: boolean;
+
+    append(nextClassifier: ClassifierScore): RollingWindow {
+        // Take MRO into account. If the classifier number is already in our list, remove the old score
+        let newHistory = this.scores.filter(c => c.classifierNumber !== nextClassifier.classifierNumber);
+        if (newHistory.length == 8) {
+            // If the window is full, remove the first entry
+            newHistory = newHistory.slice(1);
+        }
+
+        newHistory.push(nextClassifier);
+        return new RollingWindow(newHistory);
+    }
 }

--- a/src/classifications.ts
+++ b/src/classifications.ts
@@ -1,3 +1,6 @@
+import { sortBy } from "lodash/fp";
+import _ from "lodash";
+
 export interface ClassifierScore {
     date: Date,
     classifierNumber: string,
@@ -9,7 +12,7 @@ export interface ClassifierScore {
 
 export class RollingWindow {
     constructor(public readonly scores: ClassifierScore[]) {
-        this.canScore = scores.length >= 6;
+        this.canScore = scores.length >= 4;
     }
 
     public readonly canScore: boolean;
@@ -25,4 +28,77 @@ export class RollingWindow {
         newHistory.push(nextClassifier);
         return new RollingWindow(newHistory);
     }
+
+    classificationScore(): number | null {
+        if (this.canScore) {
+            const dropScoreCount = Math.min(2, this.scores.length - 4);
+            return _(this.scores)
+                .map(s => s.percent)
+                .sortBy()
+                .slice(dropScoreCount)
+                .mean();
+        }
+        return null;
+    }
+}
+
+/**
+ * Classifiers are sorted by date in ascending order.
+ * 
+ * If multiple classifiers are shot on the same day, they are sorted by percentage in ascending order.
+ */
+export function sortClassifiers(scores: ClassifierScore[]): ClassifierScore[] {
+    return sortBy<ClassifierScore>([
+        s => s.date.getTime(),
+        s => s.percent
+    ])(scores);
+}
+
+/**
+ * Indicates whether we should exclude the given score from consideration based on the given flag.
+ *
+ * We are intentionally being more permissive than USPSA here. We want to consider P- and U-flagged classifiers
+ * (pending or unpaid) so that we don't have to wait until Tuesday for stats to run to see how a recent score will
+ * affect our classification. I'm also allowing X flags (submitted while the membership was inactive) so that people
+ * can continue to track their progress even if they're not paying.
+ *
+ * These decisions are somewhat arbitrary. In the future we could consider letting the user pick which flags to
+ * exclude using checkboxes or similar.
+ */
+export function isInvalid(flag: string): boolean {
+    switch (flag) {
+        case "I": // Administrative exclusion
+        case "Q": // DQ
+        case "N": // "Did Not Fire"
+            return true;
+        default:
+            return false
+    }
+}
+
+export interface ClassificationSnapshot {
+    readonly date: Date;
+    readonly percentage: number;
+};
+
+export function getClassificationHistory(classifiers: ClassifierScore[]): ClassificationSnapshot[] {
+    let window = new RollingWindow([]);
+    return _(classifiers)
+        .sortBy([
+            s => s.date.getTime(),
+            s => s.percent
+        ]).reduce<ClassificationSnapshot[]>(
+            (hist, nextScore) => {
+                if (nextScore.flag !== undefined && !isInvalid(nextScore.flag)) {
+                    window = window.append(nextScore);
+                    if (window.canScore) {
+                        hist.push({
+                            date: nextScore.date,
+                            percentage: window.classificationScore()!
+                        });
+                    }
+                }
+                return hist;
+            }, []
+        )
 }

--- a/test/classification.test.ts
+++ b/test/classification.test.ts
@@ -4,19 +4,20 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 import { parseTextInput } from "../src/parsing";
-import { RollingWindow } from "../src/classifications";
+import { ClassifierScore, ClassificationSnapshot, getClassificationHistory, RollingWindow, sortClassifiers } from "../src/classifications";
 
 const classifierData = parseTextInput(readFileSync(join(__dirname, "data", "record.txt"), { encoding: "utf-8" }));
 
+function quickScore(date: string, classifierNumber: string, percent: number): ClassifierScore {
+    return {
+        date: new Date(date),
+        classifierNumber: classifierNumber,
+        percent: percent
+    };
+}
+
 describe("RollingWindow", () => {
     describe("append()", () => {
-        function quickScore(date: string, classifierNumber: string, percent: number): ClassifierScore {
-            return {
-                date: new Date(date),
-                classifierNumber: classifierNumber,
-                percent: percent
-            };
-        }
 
         const scores = [
             quickScore("01/01/24", "01-01", 55),
@@ -65,5 +66,116 @@ describe("RollingWindow", () => {
                 window.append(newScore).scores
             );
         });
+    });
+
+    describe("sortClassifiers()", () => {
+        it("should sort by date and percentage", () => {
+            const classifiers = [
+                quickScore("01/01/24", "01-01", 55),
+                quickScore("02/02/24", "02-01", 58),
+                quickScore("01/01/24", "01-05", 34),
+                quickScore("01/01/24", "08-09", 90),
+                quickScore("02/02/24", "07-05", 80)
+            ];
+
+            const expected = [
+                quickScore("01/01/24", "01-05", 34),
+                quickScore("01/01/24", "01-01", 55),
+                quickScore("01/01/24", "08-09", 90),
+                quickScore("02/02/24", "02-01", 58),
+                quickScore("02/02/24", "07-05", 80)
+            ]
+
+            assert.deepEqual(sortClassifiers(classifiers), expected);
+        });
+    });
+
+    describe("classificationScore()", () => {
+        it("should match USPSA's calculation for a known record", () => {
+            const score = sortClassifiers(classifierData)
+                .reduce<RollingWindow>((window, s) => window.append(s), new RollingWindow([]))
+                .classificationScore()?.toFixed(4);
+            assert.equal(score, 96.6455)
+        });
+    });
+
+    describe("getClassificationHistory()", () => {
+        const expected: ClassificationSnapshot[] = [
+            {
+                date: new Date("07/15/23"),
+                percentage: 76.80225
+            },
+            {
+                date: new Date("08/06/23"),
+                percentage: 82.60745
+            },
+            {
+                date: new Date("12/03/23"),
+                percentage: 85.32589999999999
+            },
+            {
+                date: new Date("01/07/24"),
+                percentage: 79.19494999999999
+            },
+            {
+                date: new Date("01/26/24"),
+                percentage: 82.15845999999999
+            },
+            {
+                date: new Date("03/03/24"),
+                percentage: 80.38911666666665
+            },
+            {
+                date: new Date("03/03/24"),
+                percentage: 82.87986666666666
+            },
+            {
+                date: new Date("03/03/24"),
+                percentage: 85.74546666666667
+            },
+            {
+                date: new Date("03/03/24"),
+                percentage: 88.46071666666666
+            },
+            {
+                date: new Date("03/03/24"),
+                percentage: 89.53298333333333 
+            },
+            {
+                date: new Date("03/03/24"),
+                percentage: 91.08616666666667
+            },
+            {
+                date: new Date("03/03/24"),
+                percentage: 92.42359999999998 
+            },
+            {
+                date: new Date("03/03/24"),
+                percentage: 93.42151666666666
+            },
+            {
+                date: new Date("06/02/24"),
+                percentage: 93.42151666666666
+            },
+            {
+                date: new Date("07/07/24"),
+                percentage: 94.8756
+            },
+            {
+                date: new Date("09/01/24"),
+                percentage: 94.8756
+            },
+            {
+                date: new Date("11/03/24"),
+                percentage: 96.10669999999999
+            },
+            {
+                date: new Date("06/01/25"),
+                percentage: 96.64551666666667
+            }
+        ];
+        // assert.deepEqual(getClassificationHistory(classifierData), expected);
+        const result = getClassificationHistory(classifierData)
+        expected.forEach((val, index) => assert.deepEqual(result[index], expected[index]));
     });
 });

--- a/test/classification.test.ts
+++ b/test/classification.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "mocha";
+import * as assert from "assert";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { parseTextInput } from "../src/parsing";
+import { RollingWindow } from "../src/classifications";
+
+const classifierData = parseTextInput(readFileSync(join(__dirname, "data", "record.txt"), { encoding: "utf-8" }));
+
+describe("RollingWindow", () => {
+    describe("append()", () => {
+        function quickScore(date: string, classifierNumber: string, percent: number): ClassifierScore {
+            return {
+                date: new Date(date),
+                classifierNumber: classifierNumber,
+                percent: percent
+            };
+        }
+
+        const scores = [
+            quickScore("01/01/24", "01-01", 55),
+            quickScore("02/01/24", "01-02", 56),
+            quickScore("03/01/24", "01-03", 57),
+            quickScore("04/01/24", "01-04", 58),
+            quickScore("05/01/24", "01-06", 59),
+            quickScore("06/01/24", "01-07", 59),
+            quickScore("07/01/24", "01-08", 59),
+            quickScore("08/01/24", "01-09", 59)
+        ];
+
+        it("should append classifiers until full", () => {
+            let window = new RollingWindow([]);
+            scores.forEach((score, index) => {
+                assert.deepEqual(index, window.scores.length);
+                window = window.append(score);
+                assert.deepEqual(index + 1, window.scores.length);
+            });
+            assert.deepEqual(scores, window.scores)
+
+            // Now old ones should roll off
+            const newScore = quickScore("09/01/24", "01-10", 60);
+            window = window.append(newScore);
+            assert.equal(8, window.scores.length)
+
+            const expectedScores = scores.slice(1);
+            expectedScores.push(newScore);
+            assert.deepEqual(expectedScores, window.scores);
+        });
+
+        it("should remove older scores for the same classifier", () => {
+            const window = new RollingWindow(scores);
+            const newScore = quickScore("09/01/24", "01-07", 100);
+            assert.deepEqual(
+                [
+                    quickScore("01/01/24", "01-01", 55),
+                    quickScore("02/01/24", "01-02", 56),
+                    quickScore("03/01/24", "01-03", 57),
+                    quickScore("04/01/24", "01-04", 58),
+                    quickScore("05/01/24", "01-06", 59),
+                    quickScore("07/01/24", "01-08", 59),
+                    quickScore("08/01/24", "01-09", 59),
+                    newScore
+                ],
+                window.append(newScore).scores
+            );
+        });
+    });
+});


### PR DESCRIPTION
Refactored classification history so that our percentages now match the ones on the USPSA site. I'm not sure exactly where the bug was in the old math, but this one should work and should also take MRO into account. It will also discard classifiers with certain flags (DQ, administrative removal).

I'm not discarding P, U, or X flags. This distinction is somewhat arbitrary. P and U don't matter because we should be able to see what our percentage is without having to wait for stats to run on Tuesday. I don't care about X flags because this gives people a way to track progress even if their membership lapses.

I'm also not discarding A flags because I assume anybody who shoots way above their current class probably cares that enough to get it unflagged in the future and wants to know what that did for them.