### PR TITLE
Fix typo in instructions and add parsing for major matches

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -89,7 +89,7 @@
             <button id="toggle-instructions" class="toggle-btn">Show Instructions</button>
             <div class="instructions" style="display: none;">
                 <h3>Instructions:</h3>
-                <p>Go to the <a href=https://uspsa.org/classification">USPSA classification page</a> and enter your member number. Copy the classifier table for the division of your choosing and paste it into the text box below. The app will extract dates and percentages automatically.</p>
+                <p>Go to the <a href=https://uspsa.org/classification>USPSA classification page</a> and enter your member number. Copy the classifier table for the division of your choosing and paste it into the text box below. The app will extract dates and percentages automatically.</p>
                 <p>Example format:</p>
                 <pre>Date	Number	Club	F	Percent	HF	Entered	Source
 5/15/23	23-01	BRRC	8.43	57.8	4.87	Y	WM

--- a/src/classifications.ts
+++ b/src/classifications.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 
 export interface ClassifierScore {
     date: Date,
-    classifierNumber: string,
+    classifierNumber?: string,
     percent: number,
     club?: string,
     flag?: string,

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -1,10 +1,14 @@
+import * as _ from "lodash";
+
 import { ClassifierScore } from "./classifications";
 
 export function parseLine(input: string): ClassifierScore | undefined {
     const CLASSIFIER_REGEX = new RegExp("(?<date>\\d+\\/\\d+\\/\\d+)\\s+(?<classifierNumber>\\d{2}-\\d{2})\\s+(?<club>.+[^\\s])\\s+(?<flag>[A-Z])\\s+(?<percentage>[\\d\\.]+)\\s+(?<hitFactor>[\\d\\.]+)");
-    const matchResult = input.match(CLASSIFIER_REGEX)?.groups;
+    const MAJOR_MATCH_REGEX = new RegExp("(?<date>\\d+\\/\\d+\\/\\d+)\\s+(?<club>.+[^\\s])\\s+(?<flag>[A-Z])\\s+(?<percentage>[\\d\\.]+)\\s+-\\s+-\\s+Major Match$")
+
+    const matchResult = input.match(CLASSIFIER_REGEX)?.groups ?? input.match(MAJOR_MATCH_REGEX)?.groups;
     if (matchResult != null) {
-        return {
+        const score: ClassifierScore = {
             date: new Date(matchResult["date"]),
             classifierNumber: matchResult["classifierNumber"],
             club: matchResult["club"],
@@ -12,6 +16,15 @@ export function parseLine(input: string): ClassifierScore | undefined {
             percent: parseFloat(matchResult["percentage"]),
             hitFactor: parseFloat(matchResult["hitFactor"])
         };
+
+        // Remove undefined values from optional properties
+        for (let key in score) {
+            if (score[key] === undefined || _.isNaN(score[key])) {
+                delete score[key];
+            }
+        }
+
+        return score;
     }
 
     return undefined

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -19,6 +19,17 @@ describe("parseLine", () => {
         }
         assert.deepEqual(parseLine(input1), expectedOutput);
     })
+
+    it("should parse major matches", () => {
+        const input = "6/26/24 		2024 SIG Sauer Carry Optics Nationals Presented by Vortex Optics at US01 	F 	90.8692 	- 	- 	Major Match";
+        const expectedOutput: ClassifierScore = {
+            date: new Date("6/26/24"),
+            club: "2024 SIG Sauer Carry Optics Nationals Presented by Vortex Optics at US01",
+            flag: "F",
+            percent: 90.8692
+        };
+        assert.deepEqual(parseLine(input), expectedOutput);
+    })
 })
 
 describe("parseTextInput", () => {


### PR DESCRIPTION
* Correctly balances quotation marks in the href in the instructions so that we don't send users to a 404 page
* Updates parsing code so that it can read major matches as well as numbered classifiers